### PR TITLE
Fix conditional checking that always causes build script to fail.

### DIFF
--- a/Prepare_toolchain.sh
+++ b/Prepare_toolchain.sh
@@ -11,7 +11,7 @@ apt-get -y --no-install-recommends --fix-missing install \
 	bsdtar mtools u-boot-tools pv bc \
 	gcc automake make \
 	lib32z1 lib32z1-dev qemu-user-static \
-	dosfstools libncurses5-dev lib32stdc++ debootstrap
+	dosfstools libncurses5-dev lib32stdc++-5-dev debootstrap
 
 # Prepare toolchains
 ROOT=`cd .. && pwd`

--- a/image_from_dir
+++ b/image_from_dir
@@ -22,18 +22,12 @@ cd $_DIR
 idir=linux-$distro             
 
 # ===================================================
-if [ "${2}" = "" ]; then
-    echo "Source directory not specified."
-    echo "USAGE: image_from_dir <img_name> [noformat] [2|pc|plus|one|lite|pcplus|plus2e]"
-    exit 0
-fi
-
 if [ ! -d "$idir" ] || [ ! -d  "boot-$distro" ]; then
 	sudo cp -rf $TOP/output/linux-$distro ./ 
 	sudo cp -rf $TOP/output/boot-$distro ./
 fi
 
-if [ ! -d $idir ]; then
+if [ ! -d $idir ] && [ "${2}" = "" ]; then
     echo "Source directory not found."
     echo "USAGE: image_from_dir <img_name> [noformat] [2|pc|plus|one|lite|pcplus|plus2e]"
     exit 0


### PR DESCRIPTION
create_image will call image_from_dir without any parameters causing it to fail. Even though $idir is properly set the condition did not check for this halting further image creation that would otherwise have succeeded.